### PR TITLE
Add StaffSeeder to seed staff linked to Transportation or Accommodation

### DIFF
--- a/database/factories/StaffFactory.php
+++ b/database/factories/StaffFactory.php
@@ -2,14 +2,26 @@
 
 namespace Database\Factories;
 
+use App\Models\Staff;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Staff>
+ * Factory for generating Staff model instances.
+ *
+ * Note: The polymorphic fields 'staffable_id' and 'staffable_type' 
+ * should be explicitly set when using this factory, typically in seeders,
+ * because they depend on the related model (Transportation or Accommodation).
  */
 class StaffFactory extends Factory
 {
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Staff::class;
+
     /**
      * Define the model's default state.
      *
@@ -17,13 +29,22 @@ class StaffFactory extends Factory
      */
     public function definition(): array
     {
-        $user = User::factory()->create();
-
         return [
-            'user_id' => $user->id,
-            'name' => $this->faker->name(),
-            'email' => $this->faker->unique()->safeEmail(),
-            'phone' => $this->faker->phoneNumber(),
+            // Creates or associates a User for 'user_id'
+            'user_id' => User::factory(),
+
+            // Polymorphic relation - to be set explicitly in seeder
+            'staffable_id' => null,
+            'staffable_type' => null,
+
+            // Staff member's name
+            'name' => $this->faker->name,
+
+            // Unique email for staff
+            'email' => $this->faker->unique()->safeEmail,
+
+            // Optional phone number
+            'phone' => $this->faker->optional()->phoneNumber,
         ];
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,6 +21,7 @@ class DatabaseSeeder extends Seeder
             AccommodationSeeder::class,
             TransportationOwnerPermissionSeeder::class,
             AccommodationOwnerPermissionSeeder::class,
+            StaffSeeder::class,
         ]);
     }
 }

--- a/database/seeders/StaffSeeder.php
+++ b/database/seeders/StaffSeeder.php
@@ -2,16 +2,89 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use App\Models\User;
+use App\Models\Staff;
+use App\Models\Transportation;
+use App\Models\Accommodation;
 
+/**
+ * Class StaffSeeder
+ *
+ * Seeds Staff records linked to Transportation or Accommodation entities
+ * for a limited set of users based on their user ID parity.
+ *
+ * Even user IDs get Transportation staff records.
+ * Odd user IDs get Accommodation staff records.
+ */
 class StaffSeeder extends Seeder
 {
     /**
      * Run the database seeds.
+     *
+     * Retrieves up to 10 users (or creates a default user if none exist)
+     * and seeds Staff data accordingly.
      */
     public function run(): void
     {
-        //
+        $users = User::count()
+            ? User::limit(10)->get()
+            : collect([User::create([
+                'name' => 'Default Staff User',
+                'email' => 'default.staff.user@b2bbookingapp.com',
+                'password' => bcrypt('password'),
+            ])]);
+
+        foreach ($users as $user) {
+            if ($user->id % 2 === 0) {
+                // Even user ID: seed Transportation staff
+                $this->seedModel(Transportation::class, 'phone', $user);
+            } else {
+                // Odd user ID: seed Accommodation staff
+                $this->seedModel(Accommodation::class, 'contact', $user);
+            }
+        }
+    }
+
+    /**
+     * Seeds Staff records for the given model class and user.
+     *
+     * @param  string  $modelClass   Fully qualified model class (Transportation or Accommodation)
+     * @param  string  $contactField Field name to use as phone/contact in Staff record
+     * @param  User    $user         The user to associate the staff record with
+     * @return void
+     */
+    private function seedModel(string $modelClass, string $contactField, User $user): void
+    {
+        $modelClass::all()->each(function ($entity) use ($modelClass, $contactField, $user) {
+            $email = $this->generateEmail($modelClass, $entity->id, $user->id);
+
+            Staff::firstOrCreate(
+                [
+                    'user_id' => $user->id,
+                    'staffable_id' => $entity->id,
+                    'staffable_type' => $modelClass,
+                    'email' => $email,
+                ],
+                [
+                    'name' => "{$entity->name} Staff",
+                    'phone' => $entity->{$contactField},
+                ]
+            );
+        });
+    }
+
+    /**
+     * Generates a unique staff email based on the model type, entity ID, and user ID.
+     *
+     * @param  string  $modelClass Fully qualified model class name
+     * @param  int     $entityId   ID of the Transportation or Accommodation entity
+     * @param  int     $userId     ID of the User
+     * @return string              Generated unique email
+     */
+    private function generateEmail(string $modelClass, int $entityId, int $userId): string
+    {
+        $type = strtolower(class_basename($modelClass));
+        return "staff_{$type}_{$entityId}_user{$userId}@b2bbookingapp.com";
     }
 }


### PR DESCRIPTION
- Seed up to 10 users, create default if none exist
- Assign Transportation staff to users with even IDs
- Assign Accommodation staff to users with odd IDs
- Generate unique staff emails based on model, entity, and user IDs
- Use firstOrCreate to prevent duplicate staff records
- Encapsulate seeding logic and email generation in private methods